### PR TITLE
Feat/error messages

### DIFF
--- a/src/main/java/lotto/domain/ErrorMessage.java
+++ b/src/main/java/lotto/domain/ErrorMessage.java
@@ -5,7 +5,8 @@ public enum ErrorMessage {
     DUPLICATED_NUMBER("로또 번호는 중복될 수 없습니다."),
     INVALID_LOTTO_SIZE("유효한 번호 개수가 아닙니다."),
     INVALID_LOTTO_FORMAT("당첨 번호는 콤마(\",\")로 구분되어 입력되어야합니다."),
-    NON_NUMERIC_VALUE("로또 번호는 숫자만 입력할 수 있습니다.");
+    NON_NUMERIC_VALUE("로또 번호는 숫자만 입력할 수 있습니다."),
+    INVALID_PURCHASE_UNIT("로또는 1000원 단위로만 구매할 수 있습니다.");
 
     private String message;
 

--- a/src/main/java/lotto/domain/ErrorMessage.java
+++ b/src/main/java/lotto/domain/ErrorMessage.java
@@ -6,7 +6,8 @@ public enum ErrorMessage {
     INVALID_LOTTO_SIZE("유효한 번호 개수가 아닙니다."),
     INVALID_LOTTO_FORMAT("당첨 번호는 콤마(\",\")로 구분되어 입력되어야합니다."),
     NON_NUMERIC_VALUE("로또 번호는 숫자만 입력할 수 있습니다."),
-    INVALID_PURCHASE_UNIT("로또는 1000원 단위로만 구매할 수 있습니다.");
+    INVALID_PURCHASE_UNIT("로또는 1000원 단위로만 구매할 수 있습니다."),
+    MINIMUM_PURCHASE_QUANTITY("로또는 1장 이상으로 구매하실 수 있습니다.");
 
     private String message;
 

--- a/src/main/java/lotto/domain/ErrorMessage.java
+++ b/src/main/java/lotto/domain/ErrorMessage.java
@@ -5,9 +5,10 @@ public enum ErrorMessage {
     DUPLICATED_NUMBER("로또 번호는 중복될 수 없습니다."),
     INVALID_LOTTO_SIZE("유효한 번호 개수가 아닙니다."),
     INVALID_LOTTO_FORMAT("당첨 번호는 콤마(\",\")로 구분되어 입력되어야합니다."),
-    NON_NUMERIC_VALUE("로또 번호는 숫자만 입력할 수 있습니다."),
+    NON_NUMERIC_VALUE("숫자만 입력할 수 있습니다."),
     INVALID_PURCHASE_UNIT("로또는 1000원 단위로만 구매할 수 있습니다."),
-    MINIMUM_PURCHASE_QUANTITY("로또는 1장 이상으로 구매하실 수 있습니다.");
+    MINIMUM_PURCHASE_QUANTITY("로또는 1장 이상으로 구매하실 수 있습니다."),
+    NON_POSITIVE_AMOUNT("구매 금액은 1000원 단위의 양의 정수로 구매하실 수 있습니다.");
 
     private String message;
 


### PR DESCRIPTION
## Summary 
예외 메세지 추가

## Key Changes
- NON_POSITIVE_AMOUNT : 구입 금액이 양의 정수가 아닐 경우 에러 메세지
- INVALID_PURCHASE_UNIT : 구매 금액이 로또 가격으로 나누어지지 않는 경우 에러 메세지
- MINIMUM_PURCHASE_QUANTITY : 로또 구매 장수가 1이상이 아닌 경우 에러 메세지